### PR TITLE
Update dependencies (except BDK) + various fixes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,8 +69,11 @@ jobs:
         name: portalffi-framework
         path: ./sdk/libportal-ios/portalFFI.xcframework.zip
 
-  build-firmware-device:
+  build-firmware:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        target: [device, emulator]
     steps:
     - uses: actions/checkout@v3
     - uses: cachix/install-nix-action@v22
@@ -86,10 +89,10 @@ jobs:
           ./target
           ./firmware/target
         key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
-    - run: nix-shell --run "cd firmware && cargo build --no-default-features --features device --release"
+    - run: nix-shell --run "cd firmware && cargo build --no-default-features --features ${{ matrix.target }} --release"
     - uses: actions/upload-artifact@v2
       with:
-        name: firmware
+        name: firmware-${{ matrix.target }}
         path: ./firmware/target/thumbv7em-none-eabihf/release/firmware
 
   run-firmware-tests:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -31,30 +31,30 @@ checksum = "aae1277d39aeec15cb388266ecc24b11c80469deae6067e17a1a7aa9e5c1f234"
 
 [[package]]
 name = "aead"
-version = "0.4.3"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b613b8e1e3cf911a086f53f03bf286f52fd7a7258e4fa606f0ef220d39d8877"
+checksum = "d122413f284cf2d62fb1b7db97e02edb8cda96d769b16e443a4f6195e35662b0"
 dependencies = [
+ "crypto-common",
  "generic-array",
 ]
 
 [[package]]
 name = "aes"
-version = "0.7.5"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e8b47f52ea9bae42228d07ec09eb676433d7c4ed1ebdf0f1d1c29ed446f1ab8"
+checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
 dependencies = [
  "cfg-if",
  "cipher",
  "cpufeatures",
- "opaque-debug",
 ]
 
 [[package]]
 name = "aes-gcm"
-version = "0.9.4"
+version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df5f85a83a7d8b0442b6aa7b504b8212c1733da07b98aae43d4bc21b2cb3cdf6"
+checksum = "831010a0f742e1209b3bcea8fab6a8e149051ba6099432c8cb2cc117dec3ead1"
 dependencies = [
  "aead",
  "aes",
@@ -532,11 +532,12 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "cipher"
-version = "0.3.0"
+version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ee52072ec15386f770805afd189a01c8841be8696bed250fa2f13c4c0d6dfb7"
+checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
 dependencies = [
- "generic-array",
+ "crypto-common",
+ "inout",
 ]
 
 [[package]]
@@ -704,9 +705,9 @@ dependencies = [
 
 [[package]]
 name = "ctr"
-version = "0.8.0"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "049bb91fb4aaf0e3c7efa6cd5ef877dbbbd15b39dad06d9948de4ec8a75761ea"
+checksum = "0369ee1ad671834580515889b80f2ea915f23b8be8d0daa4bbaf2ac5c7590835"
 dependencies = [
  "cipher",
 ]
@@ -1051,9 +1052,9 @@ dependencies = [
 
 [[package]]
 name = "ghash"
-version = "0.4.4"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1583cc1656d7839fd3732b80cf4f38850336cdb9b8ded1cd399ca62958de3c99"
+checksum = "f0d8a4362ccb29cb0b265253fb0a2728f592895ee6854fd9bc13f2ffda266ff1"
 dependencies = [
  "opaque-debug",
  "polyval",
@@ -1172,6 +1173,15 @@ dependencies = [
  "png",
  "scoped_threadpool",
  "tiff",
+]
+
+[[package]]
+name = "inout"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0c10553d664a4d0bcff9f4215d0aac67a639cc68ef660840afe309b807bc9f5"
+dependencies = [
+ "generic-array",
 ]
 
 [[package]]
@@ -1348,9 +1358,9 @@ dependencies = [
 
 [[package]]
 name = "minicbor"
-version = "0.20.0"
+version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d15f4203d71fdf90903c2696e55426ac97a363c67b218488a73b534ce7aca10"
+checksum = "a3d732cecc693ad7c5ea353198182ff4d9bf92428af793c411102b175855ab04"
 dependencies = [
  "minicbor-derive",
 ]
@@ -1475,18 +1485,18 @@ dependencies = [
 
 [[package]]
 name = "noise-protocol"
-version = "0.1.4"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fb474d36dfe51bb4d7e733fee2b0dfd92ee1b95c716030a70e92737dea1a52b"
+checksum = "2473d39689a839f5a363aaef7d99f76d5611bf352286682b25a6644fec18b1d3"
 dependencies = [
  "arrayvec",
 ]
 
 [[package]]
 name = "noise-rust-crypto"
-version = "0.5.0"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82e7cfeb8e6a63b4a5ccef34ed7a22d084a129b1e53a000c080bbc54c0da6f8c"
+checksum = "b4c6159f60beb3bbbcdc266bc789bfc6c37fdad7d7ca7152d3e049ef5af633f0"
 dependencies = [
  "aes-gcm",
  "noise-protocol",
@@ -1762,9 +1772,9 @@ dependencies = [
 
 [[package]]
 name = "polyval"
-version = "0.5.3"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8419d2b623c7c0896ff2d5d96e2cb4ede590fed28fcc34934f4c33c036e620a1"
+checksum = "9d1fe60d06143b2430aa532c94cfe9e29783047f06c0d7fd359a9a51b729fa25"
 dependencies = [
  "cfg-if",
  "cpufeatures",
@@ -2538,11 +2548,11 @@ dependencies = [
 
 [[package]]
 name = "universal-hash"
-version = "0.4.1"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f214e8f697e925001e66ec2c6e37a4ef93f0f78c2eed7814394e10c62025b05"
+checksum = "fc1de2c688dc15305988b563c3854064043356019f97a4b46276fe734c4f07ea"
 dependencies = [
- "generic-array",
+ "crypto-common",
  "subtle",
 ]
 

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ This command should first compile the emulator, then the firmware, and then laun
 
 The dependencies you'll need are:
 
-* **nightly** `cargo` with both the native (local) and `thumbv7em-none-eabihf` targets installed
+* `cargo` (ideally >= 1.76) with both the native (local) and `thumbv7em-none-eabihf` targets installed
 * The C toolchain for ARM-v7 (`arm-none-eabi-*`)
 * `qemu-system-arm` to emulate the firmware
 * FLTK to run the emulator GUI

--- a/emulator/src/bin/gui.rs
+++ b/emulator/src/bin/gui.rs
@@ -114,16 +114,15 @@ async fn main() -> Result<(), emulator::Error> {
 
         let cmd_args = vec!["build"];
 
-        let output = ProcessCommand::new("cargo")
+        let status = ProcessCommand::new("cargo")
             .current_dir(&args.global_opts.firmware_src_directory)
             .args(cmd_args)
-            .stdout(Stdio::inherit())
-            .stderr(Stdio::inherit())
             .stdin(Stdio::piped())
-            .output()
+            .spawn()?
+            .wait()
             .await?;
 
-        if !output.status.success() {
+        if !status.success() {
             return Err("Cargo build failed".into());
         }
     }

--- a/emulator/src/tests/mod.rs
+++ b/emulator/src/tests/mod.rs
@@ -139,8 +139,7 @@ async fn run_script(
                     }
 
                     let actual_fb = emulator.display.to_rgb_output_image(&output_settings);
-                    if actual_fb.as_image_buffer().as_raw().deref() == expected_fb.as_raw().deref()
-                    {
+                    if actual_fb.as_image_buffer().as_raw() == &expected_fb.as_raw().deref() {
                         break None;
                     }
 

--- a/firmware/Cargo.lock
+++ b/firmware/Cargo.lock
@@ -4,30 +4,30 @@ version = 3
 
 [[package]]
 name = "aead"
-version = "0.4.3"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b613b8e1e3cf911a086f53f03bf286f52fd7a7258e4fa606f0ef220d39d8877"
+checksum = "d122413f284cf2d62fb1b7db97e02edb8cda96d769b16e443a4f6195e35662b0"
 dependencies = [
+ "crypto-common",
  "generic-array",
 ]
 
 [[package]]
 name = "aes"
-version = "0.7.5"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e8b47f52ea9bae42228d07ec09eb676433d7c4ed1ebdf0f1d1c29ed446f1ab8"
+checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
 dependencies = [
  "cfg-if",
  "cipher",
  "cpufeatures",
- "opaque-debug",
 ]
 
 [[package]]
 name = "aes-gcm"
-version = "0.9.4"
+version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df5f85a83a7d8b0442b6aa7b504b8212c1733da07b98aae43d4bc21b2cb3cdf6"
+checksum = "831010a0f742e1209b3bcea8fab6a8e149051ba6099432c8cb2cc117dec3ead1"
 dependencies = [
  "aead",
  "aes",
@@ -59,15 +59,6 @@ name = "arrayvec"
 version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96d30a06541fbafbc7f82ed10c06164cfbd2c401138f6addd8404629c4b16711"
-
-[[package]]
-name = "atomic-polyfill"
-version = "0.1.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3ff7eb3f316534d83a8a2c3d1674ace8a5a71198eba31e2e2b597833f699b28"
-dependencies = [
- "critical-section",
-]
 
 [[package]]
 name = "atomic-polyfill"
@@ -183,12 +174,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
-name = "bitflags"
-version = "2.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "630be753d4e58660abd17930c71b647fe46c27ea6b63cc59e1e3851406972e42"
-
-[[package]]
 name = "bumpalo"
 version = "3.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -200,7 +185,7 @@ version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4b13b4b2ea9ab2ba924063ebb86ad895cb79f4a79bf90f27949eb20c335b30f9"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags",
  "nb 1.1.0",
  "vcell",
 ]
@@ -240,11 +225,12 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "cipher"
-version = "0.3.0"
+version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ee52072ec15386f770805afd189a01c8841be8696bed250fa2f13c4c0d6dfb7"
+checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
 dependencies = [
- "generic-array",
+ "crypto-common",
+ "inout",
 ]
 
 [[package]]
@@ -276,7 +262,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "88c26033fe85d2c5f45a173a6dadf710db4a72eb7da81dbfb795d8d9ebfaaca7"
 dependencies = [
  "cortex-m",
- "cortex-m-semihosting 0.5.0",
+ "cortex-m-semihosting",
  "log",
 ]
 
@@ -298,15 +284,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 1.0.109",
-]
-
-[[package]]
-name = "cortex-m-semihosting"
-version = "0.3.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6bffa6c1454368a6aa4811ae60964c38e6996d397ff8095a8b9211b1c1f749bc"
-dependencies = [
- "cortex-m",
 ]
 
 [[package]]
@@ -334,10 +311,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6548a0ad5d2549e111e1f6a11a6c2e2d00ce6a3dafe22948d67c2b443f775e52"
 
 [[package]]
-name = "ctr"
-version = "0.8.0"
+name = "crypto-common"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "049bb91fb4aaf0e3c7efa6cd5ef877dbbbd15b39dad06d9948de4ec8a75761ea"
+checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
+dependencies = [
+ "generic-array",
+ "typenum",
+]
+
+[[package]]
+name = "ctr"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0369ee1ad671834580515889b80f2ea915f23b8be8d0daa4bbaf2ac5c7590835"
 dependencies = [
  "cipher",
 ]
@@ -367,6 +354,15 @@ dependencies = [
  "byte-slice-cast",
  "display-interface",
  "embedded-hal 0.2.7",
+]
+
+[[package]]
+name = "document-features"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef5282ad69563b5fc40319526ba27e0e7363d552a896f0297d54f767717f9b95"
+dependencies = [
+ "litrs",
 ]
 
 [[package]]
@@ -432,18 +428,65 @@ dependencies = [
 
 [[package]]
 name = "embedded-hal"
-version = "1.0.0-alpha.8"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3babfc7fd332142a0b11aebf592992f211f4e01b6222fb04b03aba1bd80018d"
+checksum = "361a90feb7004eca4019fb28352a9465666b24f840f5c3cddf0ff13920590b89"
+
+[[package]]
+name = "embedded-hal-async"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c4c685bbef7fe13c3c6dd4da26841ed3980ef33e841cddfa15ce8a8fb3f1884"
 dependencies = [
+ "embedded-hal 1.0.0",
+]
+
+[[package]]
+name = "embedded-hal-bus"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57b4e6ede84339ebdb418cd986e6320a34b017cdf99b5cc3efceec6450b06886"
+dependencies = [
+ "critical-section",
+ "embedded-hal 1.0.0",
+ "embedded-hal-async",
+]
+
+[[package]]
+name = "embedded-hal-nb"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fba4268c14288c828995299e59b12babdbe170f6c6d73731af1b4648142e8605"
+dependencies = [
+ "embedded-hal 1.0.0",
  "nb 1.1.0",
 ]
 
 [[package]]
 name = "embedded-storage"
-version = "0.2.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "723dce4e9f25b6e6c5f35628e144794e5b459216ed7da97b7c4b66cdb3fa82ca"
+checksum = "a21dea9854beb860f3062d10228ce9b976da520a73474aed3171ec276bc0c032"
+
+[[package]]
+name = "enumflags2"
+version = "0.7.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3278c9d5fb675e0a51dabcf4c0d355f692b064171535ba72361be1528a9d8e8d"
+dependencies = [
+ "enumflags2_derive",
+]
+
+[[package]]
+name = "enumflags2_derive"
+version = "0.7.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c785274071b1b420972453b306eeca06acf4633829db4223b58a2a8c5953bc4"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.52",
+]
 
 [[package]]
 name = "equivalent"
@@ -464,12 +507,13 @@ dependencies = [
  "cortex-m",
  "cortex-m-log",
  "cortex-m-rt",
- "cortex-m-semihosting 0.3.7",
+ "cortex-m-semihosting",
  "critical-section",
  "display-interface",
  "embedded-alloc",
  "embedded-graphics-core",
  "embedded-hal 0.2.7",
+ "embedded-hal 1.0.0",
  "fetch-git-hash",
  "futures",
  "gui",
@@ -561,7 +605,7 @@ checksum = "89ca545a94061b6365f2c7355b4b32bd20df3ff95f02da9329b34ccc3bd6ee72"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.27",
+ "syn 2.0.52",
 ]
 
 [[package]]
@@ -619,9 +663,9 @@ dependencies = [
 
 [[package]]
 name = "ghash"
-version = "0.4.4"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1583cc1656d7839fd3732b80cf4f38850336cdb9b8ded1cd399ca62958de3c99"
+checksum = "f0d8a4362ccb29cb0b265253fb0a2728f592895ee6854fd9bc13f2ffda266ff1"
 dependencies = [
  "opaque-debug",
  "polyval",
@@ -637,9 +681,9 @@ dependencies = [
 
 [[package]]
 name = "hash32"
-version = "0.2.1"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0c35f58762feb77d74ebe43bdbc3210f09be9fe6742234d573bacc26ed92b67"
+checksum = "47d60b12902ba28e2730cd37e95b8c9223af2808df9e902d4df49588d1470606"
 dependencies = [
  "byteorder",
 ]
@@ -671,14 +715,11 @@ checksum = "2c6201b9ff9fd90a5a3bac2e56a830d0caa509576f0e503818ee82c181b3437a"
 
 [[package]]
 name = "heapless"
-version = "0.7.16"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db04bc24a18b9ea980628ecf00e6c0264f3c1426dac36c00cb49b6fbad8b0743"
+checksum = "0bfb9eb618601c89945a70e254898da93b13be0388091d42117462b265bb3fad"
 dependencies = [
- "atomic-polyfill 0.1.11",
  "hash32",
- "rustc_version 0.4.0",
- "spin",
  "stable_deref_trait",
 ]
 
@@ -690,6 +731,15 @@ checksum = "d5477fe2230a79769d8dc68e0eabf5437907c0457a5614a9e8dddb67f65eb65d"
 dependencies = [
  "equivalent",
  "hashbrown 0.14.0",
+]
+
+[[package]]
+name = "inout"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0c10553d664a4d0bcff9f4215d0aac67a639cc68ef660840afe309b807bc9f5"
+dependencies = [
+ "generic-array",
 ]
 
 [[package]]
@@ -720,14 +770,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9afa463f5405ee81cdb9cc2baf37e08ec7e4c8209442b5d72c04cfb2cd6e6286"
 
 [[package]]
-name = "lock_api"
-version = "0.4.10"
+name = "litrs"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1cc9717a20b1bb222f333e6a92fd32f7d8a18ddc5a3191a11af45dcbf4dcd16"
-dependencies = [
- "autocfg",
- "scopeguard",
-]
+checksum = "b4ce301924b7887e9d637144fdade93f9dfff9b60981d4ac161db09720d39aa5"
 
 [[package]]
 name = "log"
@@ -749,9 +795,9 @@ checksum = "39617bc909d64b068dcffd0e3e31679195b5576d0c83fadc52690268cc2b2b55"
 
 [[package]]
 name = "minicbor"
-version = "0.20.0"
+version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d15f4203d71fdf90903c2696e55426ac97a363c67b218488a73b534ce7aca10"
+checksum = "a3d732cecc693ad7c5ea353198182ff4d9bf92428af793c411102b175855ab04"
 dependencies = [
  "minicbor-derive",
 ]
@@ -831,18 +877,18 @@ checksum = "8d5439c4ad607c3c23abf66de8c8bf57ba8adcd1f129e699851a6e43935d339d"
 
 [[package]]
 name = "noise-protocol"
-version = "0.1.4"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fb474d36dfe51bb4d7e733fee2b0dfd92ee1b95c716030a70e92737dea1a52b"
+checksum = "2473d39689a839f5a363aaef7d99f76d5611bf352286682b25a6644fec18b1d3"
 dependencies = [
  "arrayvec",
 ]
 
 [[package]]
 name = "noise-rust-crypto"
-version = "0.5.0"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82e7cfeb8e6a63b4a5ccef34ed7a22d084a129b1e53a000c080bbc54c0da6f8c"
+checksum = "b4c6159f60beb3bbbcdc266bc789bfc6c37fdad7d7ca7152d3e049ef5af633f0"
 dependencies = [
  "aes-gcm",
  "noise-protocol",
@@ -884,15 +930,21 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "polyval"
-version = "0.5.3"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8419d2b623c7c0896ff2d5d96e2cb4ede590fed28fcc34934f4c33c036e620a1"
+checksum = "9d1fe60d06143b2430aa532c94cfe9e29783047f06c0d7fd359a9a51b729fa25"
 dependencies = [
  "cfg-if",
  "cpufeatures",
  "opaque-debug",
  "universal-hash",
 ]
+
+[[package]]
+name = "portable-atomic"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7170ef9988bc169ba16dd36a7fa041e5c4cbeb6a35b76d4c03daded371eae7c0"
 
 [[package]]
 name = "ppv-lite86"
@@ -926,18 +978,18 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.66"
+version = "1.0.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18fb31db3f9bddb2ea821cde30a9f70117e3f119938b5ee630b7403aa6e2ead9"
+checksum = "e835ff2298f5721608eb1a980ecaee1aef2c132bf95ecc026a11b7bf3c01c02e"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.32"
+version = "1.0.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50f3b39ccfb720540debaa0164757101c08ecb8d326b15358ce76a62c7e85965"
+checksum = "291ec9ab5efd934aaf503a6466c5d5251535d108ee747472c3977cc5acc868ef"
 dependencies = [
  "proc-macro2",
 ]
@@ -975,11 +1027,11 @@ checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 
 [[package]]
 name = "rtic"
-version = "2.0.1"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "857ce76a2517808a303bcb7e5b6d4a9c1d84e5de88b302aec2e53744633c0f4d"
+checksum = "0f9472edf226fafcaec0af8afeac6d22b28bf4fdbe7c34762b82af540c081f9a"
 dependencies = [
- "atomic-polyfill 1.0.3",
+ "atomic-polyfill",
  "bare-metal 1.0.0",
  "cortex-m",
  "critical-section",
@@ -1004,46 +1056,51 @@ checksum = "d9369355b04d06a3780ec0f51ea2d225624db777acbc60abd8ca4832da5c1a42"
 
 [[package]]
 name = "rtic-macros"
-version = "2.0.1"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8617533990b728e31bc65fcec8fec51fa1b4000fb33189ebeb05fb9d8625444d"
+checksum = "54053598ea24b1b74937724e366558412a1777eb2680b91ef646db540982789a"
 dependencies = [
  "indexmap",
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.52",
 ]
 
 [[package]]
 name = "rtic-monotonics"
-version = "1.0.0"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b7b43766f637098795e97a759006a09f79e710b3c8df9cb5070abdac59c158e"
+checksum = "058c2397dbd5bb4c5650a0e368c3920953e458805ff5097a0511b8147b3619d7"
 dependencies = [
- "atomic-polyfill 1.0.3",
+ "atomic-polyfill",
  "cfg-if",
  "cortex-m",
+ "embedded-hal 1.0.0",
  "fugit",
  "rtic-time",
 ]
 
 [[package]]
 name = "rtic-sync"
-version = "1.0.1"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdb1b1b0ca716573360416a4f32e6eda76421e3695ad476ef44243c304748bfa"
+checksum = "49b1200137ccb2bf272a1801fa6e27264535facd356cb2c1d5bc8e12aa211bad"
 dependencies = [
  "critical-section",
+ "embedded-hal 1.0.0",
+ "embedded-hal-async",
+ "embedded-hal-bus",
  "heapless",
+ "portable-atomic",
  "rtic-common",
 ]
 
 [[package]]
 name = "rtic-time"
-version = "1.0.0"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55127cfa37ad32522eca2b70a12298bdb035c75ee3a4e403af8773ffe1a64bd3"
+checksum = "75b232e7aebc045cfea81cdd164bc2727a10aca9a4568d406d0a5661cdfd0f19"
 dependencies = [
  "critical-section",
  "futures-util",
@@ -1052,9 +1109,9 @@ dependencies = [
 
 [[package]]
 name = "rtt-log"
-version = "0.2.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e6ba09884211bb4594535abfbb24ad8cce2d07ab98d0687303c00a29d655105"
+checksum = "934c5a2ab52e91070e60e400ed9c9f2f28d9469b06b974e5d463e98bc7c0e185"
 dependencies = [
  "log",
  "rtt-target",
@@ -1062,9 +1119,9 @@ dependencies = [
 
 [[package]]
 name = "rtt-target"
-version = "0.4.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3afa12c77ba1b9bf560e4039a9b9a08bb9cde0e9e6923955eeb917dd8d5cf303"
+checksum = "10b34c9e6832388e45f3c01f1bb60a016384a0a4ad80cdd7d34913bed25037f0"
 dependencies = [
  "critical-section",
  "ufmt-write",
@@ -1093,12 +1150,6 @@ name = "ryu"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ad4cc8da4ef723ed60bced201181d83791ad433213d8c24efffda1eec85d741"
-
-[[package]]
-name = "scopeguard"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "secp256k1"
@@ -1158,7 +1209,7 @@ checksum = "b23f7ade6f110613c0d63858ddb8b94c1041f550eab58a16b371bdf2c9c80ab4"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.27",
+ "syn 2.0.52",
 ]
 
 [[package]]
@@ -1170,15 +1221,6 @@ dependencies = [
  "itoa",
  "ryu",
  "serde",
-]
-
-[[package]]
-name = "spin"
-version = "0.9.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
-dependencies = [
- "lock_api",
 ]
 
 [[package]]
@@ -1220,24 +1262,27 @@ dependencies = [
 
 [[package]]
 name = "stm32f4xx-hal"
-version = "0.16.2"
+version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc2877159274bc374744f10a4dd913b5175593ce02a94d70b8ba978e49db199b"
+checksum = "10c41454f262c0be0c35b8cfc0d971e598281f7a9be32e894dc97a0b21deadfe"
 dependencies = [
  "bare-metal 1.0.0",
- "bitflags 2.3.3",
  "cortex-m",
  "cortex-m-rt",
+ "document-features",
  "embedded-dma 0.2.0",
  "embedded-hal 0.2.7",
- "embedded-hal 1.0.0-alpha.8",
+ "embedded-hal 1.0.0",
+ "embedded-hal-nb",
  "embedded-storage",
+ "enumflags2",
  "fugit",
  "fugit-timer",
  "nb 1.1.0",
  "rand_core 0.6.4",
  "stm32f4",
  "time",
+ "vcell",
  "void",
 ]
 
@@ -1291,9 +1336,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.27"
+version = "2.0.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b60f673f44a8255b9c8c657daf66a596d435f2da81a555b06dc644d080ba45e0"
+checksum = "b699d15b36d1f02c3e7c69f8ffef53de37aefae075d8488d4ba1a7788d574a07"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1335,11 +1380,11 @@ checksum = "301abaae475aa91687eb82514b328ab47a211a533026cb25fc3e519b86adfc3c"
 
 [[package]]
 name = "universal-hash"
-version = "0.4.1"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f214e8f697e925001e66ec2c6e37a4ef93f0f78c2eed7814394e10c62025b05"
+checksum = "fc1de2c688dc15305988b563c3854064043356019f97a4b46276fe734c4f07ea"
 dependencies = [
- "generic-array",
+ "crypto-common",
  "subtle",
 ]
 
@@ -1397,7 +1442,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.27",
+ "syn 2.0.52",
  "wasm-bindgen-shared",
 ]
 
@@ -1419,7 +1464,7 @@ checksum = "54681b18a46765f095758388f2d0cf16eb8d4169b639ab575a8f5693af210c7b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.27",
+ "syn 2.0.52",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]

--- a/firmware/Cargo.toml
+++ b/firmware/Cargo.toml
@@ -5,20 +5,19 @@ edition = "2021"
 license = "GPL-3.0-or-later"
 
 [dependencies]
-rtic = { version = "2.0", features = ["thumbv7-backend"] }
-rtic-sync = "1.0"
-rtic-monotonics = { version = "1.0", features = ["cortex-m-systick"] }
+rtic = { version = "2.1", features = ["thumbv7-backend"] }
+rtic-sync = "1.3"
+rtic-monotonics = { version = "1.5", features = ["cortex-m-systick"] }
 critical-section = "1.1"
 cortex-m = { version = "^0.7.7", features = ["critical-section-single-core"] }
 # set-vtor: set vector table to the flash address rather than relying
 #   on the default value of 0x0 which is fine when booting from bank 1
 #   (because memory is aliased) but would break with bank 2
-cortex-m-rt = { version = "0.7.2", features = ["set-vtor"] }
+cortex-m-rt = { version = "0.7.3", features = ["set-vtor"] }
 embedded-alloc = "0.5"
-embedded-hal = "0.2.7"
 display-interface = "^0.4.1"
 ssd1306 = "0.8"
-minicbor = { version = "0.20", default-features = false, features = ["alloc"] }
+minicbor = { version = "0.21", default-features = false, features = ["alloc", "derive"] }
 rand = { version = "0.8", default-features = false }
 rand_chacha = { version = "0.3", default-features = false }
 log = "0.4"
@@ -32,22 +31,25 @@ fetch-git-hash = { path = "../fetch-git-hash" }
 model = { path = "../model", features = ["stm32"] }
 gui = { path = "../gui", features = ["stm32"] }
 
-rtt-target = { version = "0.4", optional = true }
-rtt-log = { version = "0.2", optional = true }
+embedded-hal-1 = { package = "embedded-hal", version = "1.0.0", optional = true }
+embedded-hal-02 = { package = "embedded-hal", version = "0.2.6", optional = true }
+
+rtt-target = { version = "0.5", optional = true }
+rtt-log = { version = "0.3", optional = true }
 stm32l4xx-hal = { version = "0.7.1", features = ["stm32l476", "rt"], optional = true }
 
 # panic-probe = { version = "0.2", features = ["print-rtt"], optional = true }
-cortex-m-semihosting = { version = "0.3.5", optional = true }
+cortex-m-semihosting = { version = "0.5", optional = true }
 cortex-m-log = { version = "0.8", features = ["log-integration", "semihosting"], optional = true}
 # panic-semihosting = { version = "0.6", optional = true }
-stm32f4xx-hal = { version = "0.16.2", features = ["stm32f405"], optional = true }
+stm32f4xx-hal = { version = "0.20", features = ["stm32f405"], optional = true }
 embedded-graphics-core = { version = "0.4", optional = true }
 
 [features]
 default = ["emulator", "panic-log"]
-emulator = ["cortex-m-semihosting", "cortex-m-log", "stm32f4xx-hal", "embedded-graphics-core", "model/emulator", "panic-log"] # "panic-semihosting", "panic-semihosting/exit"
+emulator = ["cortex-m-semihosting", "cortex-m-log", "stm32f4xx-hal", "embedded-graphics-core", "model/emulator", "panic-log", "embedded-hal-1"] # "panic-semihosting", "panic-semihosting/exit"
 emulator-fast-ticks = []
-device = ["rtt-target", "rtt-log", "stm32l4xx-hal"] # "panic-probe"
+device = ["rtt-target", "rtt-log", "stm32l4xx-hal", "embedded-hal-02"] # "panic-probe"
 trace_memory = []
 panic-log = []
 

--- a/firmware/linker-scripts/emulator/memory.x
+++ b/firmware/linker-scripts/emulator/memory.x
@@ -5,8 +5,10 @@ MEMORY
     DATA (r) : ORIGIN = 0x0807F800, LENGTH = 2K
     /* Use the largest section of memory for the HEAP */
     HEAP (rw) : ORIGIN = 0x20000000, LENGTH = 96K
-    /* And place the stack in SRAM2 which should be more than enough */
-    RAM (rw) : ORIGIN = 0x10000000, LENGTH = 32K
+    /* On the real device we place the stack in SRAM2 at 0x10000000 but
+       older versions of QEMU (< 8.2) don't emulate this section, so we just
+       put it after the heap */
+    RAM (rw) : ORIGIN = 0x20018000, LENGTH = 32K
 }
 
 SECTIONS

--- a/firmware/src/emulator/hw.rs
+++ b/firmware/src/emulator/hw.rs
@@ -80,7 +80,7 @@ pub fn init_peripherals(
             &clocks,
         )
         .unwrap();
-    serial.listen(serial::Event::Rxne);
+    serial.listen(serial::Event::RxNotEmpty);
     set_serial(serial);
 
     let (nfc, nfc_interrupt, nfc_finished) = NfcIc::new();

--- a/firmware/src/main.rs
+++ b/firmware/src/main.rs
@@ -19,12 +19,14 @@
 #![no_main]
 #![allow(non_camel_case_types)]
 #![allow(non_upper_case_globals)]
-#![feature(type_alias_impl_trait)]
-#![feature(unboxed_closures)]
 
 extern crate alloc;
 extern crate cortex_m;
-extern crate embedded_hal as ehal;
+
+#[cfg(feature = "device")]
+extern crate embedded_hal_02 as ehal;
+#[cfg(feature = "emulator")]
+extern crate embedded_hal_1 as ehal;
 
 #[cfg(all(feature = "device", feature = "emulator"))]
 compile_error!("Cannot enable both the `device` and `emulator` features at the same time");
@@ -181,6 +183,7 @@ mod app {
         // TODO: move this somewhere else
         dp.RCC.apb2enr.write(|w| w.syscfgen().set_bit());
 
+        #[allow(unused_mut)]
         let (mut nfc, nfc_interrupt, nfc_finished, display, tsc, rng, flash) =
             hw::init_peripherals(dp, cp).unwrap();
 

--- a/model/Cargo.toml
+++ b/model/Cargo.toml
@@ -7,13 +7,13 @@ license = "GPL-3.0-or-later"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-minicbor = { version = "0.20", default-features = false, features = ["derive", "alloc"] }
+minicbor = { version = "0.21", default-features = false, features = ["derive", "alloc"] }
 modular-bitfield = "0.11.2"
 bitcoin = { version = "0.29.2", default-features = false, features = ["no-std", "serde"] }
 bip39 = { version = "1.2.0", default-features = false }
-noise-protocol = { version = "0.1.4", default-features = false, features = ["use_alloc"] }
-noise-rust-crypto = { version = "0.5.0", default-features = false, features = ["use-aes-256-gcm"] }
-aes-gcm = { version = "0.9.4" }
+noise-protocol = { version = "0.2.0", default-features = false, features = ["use_alloc"] }
+noise-rust-crypto = { version = "0.6.2", default-features = false, features = ["use-aes-256-gcm"] }
+aes-gcm = { version = "0.10.3", default-features = false, features = ["aes", "alloc"] }
 log = "0.4"
 
 serde = { version = "1.0", default-features = false, features = ["alloc", "derive"], optional = true }

--- a/shell.nix
+++ b/shell.nix
@@ -9,8 +9,8 @@ let
   rust_overlay = import (builtins.fetchTarball "https://github.com/oxalica/rust-overlay/archive/master.tar.gz");
   pkgs = import <nixpkgs> { overlays = [ rust_overlay ]; config.android_sdk.accept_license = true; config.allowUnfree = true; };
   lib = pkgs.lib;
-  rustVersion = "2023-07-07";
-  rust = pkgs.rust-bin.nightly.${rustVersion}.default.override {
+  rustVersion = "1.76.0";
+  rust = pkgs.rust-bin.stable.${rustVersion}.default.override {
     extensions = [
       "rust-src" # for rust-analyzer
     ];
@@ -81,7 +81,7 @@ pkgs.mkShell rec {
     pkgs.libusb
     rust
   ]
-    ++ lib.optionals withEmbedded (with pkgs; [ probe-run gcc-arm-embedded qemu gdb openocd hal clang ])
+    ++ lib.optionals withEmbedded (with pkgs; [ probe-rs gcc-arm-embedded qemu gdb openocd hal clang ])
     ++ lib.optionals withAndroid (with pkgs; [ cargo-ndk jdk ]);
 
   RUST_BACKTRACE = 1;


### PR DESCRIPTION
While we wait for the firmware size regression to be fixed (see #1), update all the other dependencies and apply fixes for older versions of QEMU.