### PR TITLE
Enable cross-language LTO

### DIFF
--- a/firmware/.cargo/config
+++ b/firmware/.cargo/config
@@ -6,7 +6,12 @@ rustflags = [
   # use the Tlink.x scrip from the cortex-m-rt crate
   "-C", "link-arg=-Tlink.x",
   # Use v0 symbol mangling style (https://rust-lang.github.io/rfcs/2603-rust-symbol-name-mangling-v0.html). This allows recovering the full monomorphized type from the symbol name
-  "-C", "symbol-mangling-version=v0"
+  "-C", "symbol-mangling-version=v0",
+  "-C", "linker-plugin-lto",
+  "-C", "linker=clang",
+  "-C", "link-arg=-fuse-ld=lld",
+  "-C", "link-arg=-flto",
+  "-C", "link-arg=--target=thumbv7em-none-eabihf"
 ]
 
 # Doesn't seem to work but let's keep it here so we can find it when needed

--- a/flake.nix
+++ b/flake.nix
@@ -75,7 +75,7 @@
         };
 
         defaultDeps = with pkgs; [ cmake SDL2 fltk pango rust-analyzer pkg-config libusb ];
-        embeddedDeps = with pkgs; [ probe-rs gcc-arm-embedded qemu gdb openocd clang (getRust { withEmbedded = true; }) ];
+        embeddedDeps = with pkgs; [ probe-rs qemu gdb openocd clang_17 lld_17 (getRust { withEmbedded = true; }) ];
         androidDeps = with pkgs; [ cargo-ndk jdk gnupg (getRust { fullAndroid = true; }) ];
         iosDeps = with pkgs; [ (getRust { withIos = true; }) ];
       in
@@ -87,7 +87,9 @@
         devShells.embedded = pkgs.mkShell {
           buildInputs = defaultDeps ++ embeddedDeps ++ [ packages.hal ];
 
-          CC_thumbv7em_none_eabihf = "${pkgs.gcc-arm-embedded}/bin/arm-none-eabi-gcc";
+          CC_thumbv7em_none_eabihf = "clang";
+          CFLAGS_thumbv7em_none_eabihf = "-fembed-bitcode -fno-PIC -flto=thin -fno-stack-protector -target thumbv7em-none-eabihf";
+          CRATE_CC_NO_DEFAULTS = "true";
         };
         devShells.android = pkgs.mkShell rec {
           buildInputs = defaultDeps ++ androidDeps;


### PR DESCRIPTION
Compile the C dependencies of the firmware using clang and enable LTO across Rust and C sources